### PR TITLE
feat: add Kiro (AWS IDE) adapter via steering file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Semantic Versi
 
 ## [Unreleased]
 
-*No unreleased changes queued.*
+### Added
+
+- **Kiro (AWS IDE) adapter** via steering file (`install_mode: owned-file`). `agent-style enable kiro` writes `.kiro/steering/agent-style.md` with `inclusion: auto` frontmatter; Kiro loads steering files into every agent interaction, so the 21 rules apply to all prose generation in the workspace. Same 5-point content contract as the other primary adapters (versioned self-verification handshake, compact directives, load statement, full-body pointer, escape hatch). `adapter-matrix.md` bumped to 9 primary adapters plus the `style-review` skill. Contributed by @Alex-jjh ([#2](https://github.com/yzhao062/agent-style/pull/2)).
 
 ## [0.2.0] — 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See [`RULES.md`](RULES.md) for the full per-rule blocks with BAD/GOOD examples, 
 
 ## Who It Is For
 
-- **AI coding and writing agents:** Claude Code, Codex, GitHub Copilot, Cursor, Aider, Anthropic Skills, Replit Agent, Windsurf, Amazon Q Developer, JetBrains AI Assistant, Ollama, Continue.dev, Tabnine, OpenCode, OpenAI Agents SDK skills, and any `AGENTS.md`-compliant tool. Each agent reads the ruleset as part of its system prompt or project config.
+- **AI coding and writing agents:** Claude Code, Codex, GitHub Copilot, Cursor, Aider, Anthropic Skills, Kiro, Replit Agent, Windsurf, Amazon Q Developer, JetBrains AI Assistant, Ollama, Continue.dev, Tabnine, OpenCode, OpenAI Agents SDK skills, and any `AGENTS.md`-compliant tool. Each agent reads the ruleset as part of its system prompt or project config.
 - **Maintainers of those agents' configurations** who want generated prose to follow literature-backed writing conventions rather than reproduce common LLM tell-patterns.
 
 ## Use
@@ -139,6 +139,7 @@ agent-style disable <tool>                           # reverse an enable
 - **Cursor, Copilot path-scoped, Anthropic Skills (`owned-file`)**: writes a new agent-style-owned file at the tool's rule-directory path (`.cursor/rules/agent-style.mdc`, `.github/instructions/agent-style.instructions.md`, `.claude/skills/agent-style/SKILL.md`). Fails closed if a non-agent-style file is already there.
 - **Codex API (`print-only`)**: writes `.agent-style/codex-system-prompt.md`; prints the prompt body to stdout, manual-step instructions to stderr. You paste the prompt into your Codex API `system_prompt`.
 - **Aider (`multi-file-required`)**: writes `.agent-style/aider-conventions.md`; prints a `.aider.conf.yml` snippet to stderr. You paste both files into the config.
+- **Kiro (`owned-file`)**: writes `.kiro/steering/agent-style.md` as an auto-included steering file. Kiro loads it at session start for every interaction in the workspace.
 
 For `print-only` and `multi-file-required`, the JSON output carries `manual_step_required: true` and `enabled: false`; exit code stays 0 (the CLI did everything it can do) and the first line of human output is exactly `manual step required:` followed by the specific action.
 
@@ -158,6 +159,7 @@ For `print-only` and `multi-file-required`, the JSON output carries `manual_step
 | Anthropic Skills | `owned-file` | `.claude/skills/agent-style/SKILL.md` |
 | Codex (API / manual paste) | `print-only` | `.agent-style/codex-system-prompt.md` (user pastes into API system prompt) |
 | Aider | `multi-file-required` | `.agent-style/aider-conventions.md` + `.aider.conf.yml` snippet |
+| Kiro (AWS IDE) | `owned-file` | `.kiro/steering/agent-style.md` |
 | **style-review** (skill) | `skill-with-references` | `.claude/skills/style-review/SKILL.md` + `.agent-style/skills/style-review/references/` |
 
 Amazon Q Developer, JetBrains AI Assistant, Windsurf, Ollama, Replit, OpenCode, Continue.dev, Tabnine, OpenAI Agents SDK skills, and Copilot path-scoped variants beyond the above are planned for v1.1; see the "Planned adapters" section of [`adapter-matrix.md`](adapter-matrix.md).

--- a/adapter-matrix.md
+++ b/adapter-matrix.md
@@ -2,7 +2,7 @@
 
 # Adapter Matrix
 
-Every shipped adapter file in `agents/`, with its target path, install mode, and load class. v0.2.0 ships 8 primary adapters; 11 additional tool surfaces are on the v1.1 "Planned adapters" roadmap.
+Every shipped adapter file in `agents/`, with its target path, install mode, and load class. v0.2.0 ships 9 primary adapters plus the `style-review` skill; 10 additional tool surfaces are on the v1.1 "Planned adapters" roadmap.
 
 ## Primary Adapters (v0.2.0, Shipped)
 
@@ -16,6 +16,7 @@ Every shipped adapter file in `agents/`, with its target path, install mode, and
 | GitHub Copilot (path-scoped) | `agents/copilot-path-instructions.md` | `.github/instructions/agent-style.instructions.md` | `owned-file` | single-file |
 | Cursor | `agents/cursor-rule.mdc` | `.cursor/rules/agent-style.mdc` | `owned-file` | single-file |
 | Aider | `agents/aider-conventions.md` | `.agent-style/aider-conventions.md` + `.aider.conf.yml` snippet | `multi-file-required` | multi-file-required |
+| Kiro (AWS IDE) | `agents/kiro-steering.md` | `.kiro/steering/agent-style.md` | `owned-file` | single-file |
 
 **Install**: run `agent-style enable <tool>` (creates `.agent-style/RULES.md`, copies the adapter, safe-appends or writes the target file), or follow the manual `curl` recipe in `README.md` for equivalent manual steps. Both paths never overwrite existing user content.
 

--- a/agents/kiro-steering.md
+++ b/agents/kiro-steering.md
@@ -1,0 +1,57 @@
+---
+description: "agent-style v0.2.0 — literature-backed technical-prose writing rules for AI agents"
+inclusion: auto
+---
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Adapter: Kiro (AWS IDE steering file) -->
+<!-- Target path: .kiro/steering/agent-style.md -->
+<!-- Load class: single-file; install_mode: owned-file -->
+
+# agent-style v0.2.0 — Kiro Steering Adapter
+
+agent-style is a literature-backed English technical-prose writing ruleset for AI agents. This adapter is a Kiro steering file at `.kiro/steering/agent-style.md`. Kiro loads steering files with `inclusion: auto` into every agent interaction, so the 21 rules below reach context for all prose generation in this workspace.
+
+## Self-Verification Handshake
+
+When asked "is agent-style active?" or "what writing rules apply here?", answer: `agent-style v0.2.0 active: 21 rules (RULE-01..12 canonical + RULE-A..I field-observed); full bodies at .agent-style/RULES.md.`
+
+## Load Statement
+
+Kiro loads `.kiro/steering/*.md` files at session start. Files with `inclusion: auto` frontmatter are included in every interaction. This file uses `inclusion: auto` so the writing rules apply to all prose generation. For conditional loading (only when editing prose files), change the frontmatter to `inclusion: fileMatch` with `fileMatchPattern: "**/*.md,**/*.tex,**/*.rst,**/*.txt"`.
+
+## The 21 Rules (Compact Directives)
+
+Canonical rules (from Strunk & White 1959, Orwell 1946, Pinker 2014, Gopen & Swan 1990):
+
+- **RULE-01 Curse of knowledge**: Name your intended reader; do not assume they share your tacit knowledge.
+- **RULE-02 Passive voice**: Prefer active voice when the agent is known and worth naming.
+- **RULE-03 Concrete language**: Prefer concrete, specific terms over abstract category words like "factors" or "aspects".
+- **RULE-04 Needless words**: Cut filler phrases like "in order to", "due to the fact that", "may potentially".
+- **RULE-05 Dying metaphors**: Delete clichés like "pushes the boundaries", "paradigm shift", or "state of the art".
+- **RULE-06 Plain English**: Prefer "use" over "leverage", "method" over "methodology", "feature" over "functionality".
+- **RULE-07 Affirmative form**: Prefer "trivial" to "not important", "forgot" to "did not remember".
+- **RULE-08 Claim calibration**: Calibrate verbs to evidence; do not write "proves" when the evidence is "suggests".
+- **RULE-09 Parallel structure**: Express coordinate ideas in the same grammatical form.
+- **RULE-10 Related words together**: Keep subject close to verb and modifier close to modified; split long parentheticals.
+- **RULE-11 Stress position**: Place new or important information at the end of the sentence.
+- **RULE-12 Long sentences**: Split sentences over 30 words; vary length across a paragraph.
+
+Field-observed rules (maintainer observation of LLM output, 2022-2026):
+
+- **RULE-A Bullet overuse**: Keep prose in paragraphs when ideas connect; bullets only for genuine lists; avoid forced 3-item triads.
+- **RULE-B Dash overuse**: Do not use em or en dashes as casual sentence punctuation; prefer commas, semicolons, colons, parentheses.
+- **RULE-C Same-starts**: Do not open two or more consecutive sentences with the same word.
+- **RULE-D Transitions**: Do not open sentences with "Additionally", "Furthermore", "Moreover", "In addition".
+- **RULE-E Summary closers**: Do not end every paragraph with a sentence that restates its point.
+- **RULE-F Term consistency**: Once you define a term or abbreviation, keep using it; do not alternate synonyms.
+- **RULE-G Title case**: Use title case for section and subsection headings; articles and short prepositions stay lowercase.
+- **RULE-H Citation discipline (critical)**: Support factual claims with verifiable citation or concrete evidence; never fabricate citations.
+- **RULE-I Contractions**: Prefer "it is" / "does not" / "cannot" over "it's" / "doesn't" / "can't" in formal technical prose.
+
+## Escape Hatch
+
+*"Break any of these rules sooner than say anything outright barbarous."* — George Orwell, "Politics and the English Language" (1946), Rule 6. Rules are guides to clarity, not ends in themselves.
+
+## Full Rule Bodies (Canonical)
+
+Full directive text, BAD/GOOD example pairs, and rationale per rule: see `.agent-style/RULES.md` in this project, or https://raw.githubusercontent.com/yzhao062/agent-style/v0.2.0/RULES.md for the pinned canonical source.

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -45,6 +45,7 @@ Supported tools and install modes in v0.2.0:
 | anthropic-skill | owned-file |
 | codex | print-only |
 | aider | multi-file-required |
+| kiro | owned-file |
 
 Canonical repository: https://github.com/yzhao062/agent-style
 

--- a/packages/npm/data/agents/kiro-steering.md
+++ b/packages/npm/data/agents/kiro-steering.md
@@ -1,0 +1,57 @@
+---
+description: "agent-style v0.2.0 — literature-backed technical-prose writing rules for AI agents"
+inclusion: auto
+---
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Adapter: Kiro (AWS IDE steering file) -->
+<!-- Target path: .kiro/steering/agent-style.md -->
+<!-- Load class: single-file; install_mode: owned-file -->
+
+# agent-style v0.2.0 — Kiro Steering Adapter
+
+agent-style is a literature-backed English technical-prose writing ruleset for AI agents. This adapter is a Kiro steering file at `.kiro/steering/agent-style.md`. Kiro loads steering files with `inclusion: auto` into every agent interaction, so the 21 rules below reach context for all prose generation in this workspace.
+
+## Self-Verification Handshake
+
+When asked "is agent-style active?" or "what writing rules apply here?", answer: `agent-style v0.2.0 active: 21 rules (RULE-01..12 canonical + RULE-A..I field-observed); full bodies at .agent-style/RULES.md.`
+
+## Load Statement
+
+Kiro loads `.kiro/steering/*.md` files at session start. Files with `inclusion: auto` frontmatter are included in every interaction. This file uses `inclusion: auto` so the writing rules apply to all prose generation. For conditional loading (only when editing prose files), change the frontmatter to `inclusion: fileMatch` with `fileMatchPattern: "**/*.md,**/*.tex,**/*.rst,**/*.txt"`.
+
+## The 21 Rules (Compact Directives)
+
+Canonical rules (from Strunk & White 1959, Orwell 1946, Pinker 2014, Gopen & Swan 1990):
+
+- **RULE-01 Curse of knowledge**: Name your intended reader; do not assume they share your tacit knowledge.
+- **RULE-02 Passive voice**: Prefer active voice when the agent is known and worth naming.
+- **RULE-03 Concrete language**: Prefer concrete, specific terms over abstract category words like "factors" or "aspects".
+- **RULE-04 Needless words**: Cut filler phrases like "in order to", "due to the fact that", "may potentially".
+- **RULE-05 Dying metaphors**: Delete clichés like "pushes the boundaries", "paradigm shift", or "state of the art".
+- **RULE-06 Plain English**: Prefer "use" over "leverage", "method" over "methodology", "feature" over "functionality".
+- **RULE-07 Affirmative form**: Prefer "trivial" to "not important", "forgot" to "did not remember".
+- **RULE-08 Claim calibration**: Calibrate verbs to evidence; do not write "proves" when the evidence is "suggests".
+- **RULE-09 Parallel structure**: Express coordinate ideas in the same grammatical form.
+- **RULE-10 Related words together**: Keep subject close to verb and modifier close to modified; split long parentheticals.
+- **RULE-11 Stress position**: Place new or important information at the end of the sentence.
+- **RULE-12 Long sentences**: Split sentences over 30 words; vary length across a paragraph.
+
+Field-observed rules (maintainer observation of LLM output, 2022-2026):
+
+- **RULE-A Bullet overuse**: Keep prose in paragraphs when ideas connect; bullets only for genuine lists; avoid forced 3-item triads.
+- **RULE-B Dash overuse**: Do not use em or en dashes as casual sentence punctuation; prefer commas, semicolons, colons, parentheses.
+- **RULE-C Same-starts**: Do not open two or more consecutive sentences with the same word.
+- **RULE-D Transitions**: Do not open sentences with "Additionally", "Furthermore", "Moreover", "In addition".
+- **RULE-E Summary closers**: Do not end every paragraph with a sentence that restates its point.
+- **RULE-F Term consistency**: Once you define a term or abbreviation, keep using it; do not alternate synonyms.
+- **RULE-G Title case**: Use title case for section and subsection headings; articles and short prepositions stay lowercase.
+- **RULE-H Citation discipline (critical)**: Support factual claims with verifiable citation or concrete evidence; never fabricate citations.
+- **RULE-I Contractions**: Prefer "it is" / "does not" / "cannot" over "it's" / "doesn't" / "can't" in formal technical prose.
+
+## Escape Hatch
+
+*"Break any of these rules sooner than say anything outright barbarous."* — George Orwell, "Politics and the English Language" (1946), Rule 6. Rules are guides to clarity, not ends in themselves.
+
+## Full Rule Bodies (Canonical)
+
+Full directive text, BAD/GOOD example pairs, and rationale per rule: see `.agent-style/RULES.md` in this project, or https://raw.githubusercontent.com/yzhao062/agent-style/v0.2.0/RULES.md for the pinned canonical source.

--- a/packages/npm/data/tools.json
+++ b/packages/npm/data/tools.json
@@ -52,6 +52,12 @@
       "load_class": "multi-file-required",
       "second_file_snippet": "read:\n  - .agent-style/aider-conventions.md\n  - .agent-style/RULES.md\n"
     },
+    "kiro": {
+      "install_mode": "owned-file",
+      "target_path": ".kiro/steering/agent-style.md",
+      "adapter_source": "agents/kiro-steering.md",
+      "load_class": "single-file"
+    },
     "style-review": {
       "install_mode": "skill-with-references",
       "skill_source": "skills/style-review/SKILL.md",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-style",
   "version": "0.2.0",
-  "description": "The Elements of Agent Style: a literature-backed English technical-prose writing ruleset for AI agents, with CLI install/enable/disable for 8 primary agent surfaces.",
+  "description": "The Elements of Agent Style: a literature-backed English technical-prose writing ruleset for AI agents, with CLI install/enable/disable for 9 primary agent surfaces.",
   "keywords": [
     "writing",
     "style",

--- a/packages/pypi/README.md
+++ b/packages/pypi/README.md
@@ -34,8 +34,9 @@ Supported tools and install modes in v0.2.0:
 | anthropic-skill | owned-file (writes `.claude/skills/agent-style/SKILL.md`) |
 | codex | print-only (writes `.agent-style/codex-system-prompt.md`; stdout = prompt) |
 | aider | multi-file-required (writes `.agent-style/aider-conventions.md`; stderr = `.aider.conf.yml` snippet) |
+| kiro | owned-file (writes `.kiro/steering/agent-style.md`) |
 
-The full rule set lives in the canonical repository at https://github.com/yzhao062/agent-style. This PyPI package bundles `RULES.md`, `NOTICE.md`, the 8 primary adapters, and the `tools.json` registry; running `agent-style rules` prints the bundled `RULES.md` for quick review.
+The full rule set lives in the canonical repository at https://github.com/yzhao062/agent-style. This PyPI package bundles `RULES.md`, `NOTICE.md`, the 9 primary adapters, and the `tools.json` registry; running `agent-style rules` prints the bundled `RULES.md` for quick review.
 
 ## License
 

--- a/packages/pypi/agent_style/data/agents/kiro-steering.md
+++ b/packages/pypi/agent_style/data/agents/kiro-steering.md
@@ -1,0 +1,57 @@
+---
+description: "agent-style v0.2.0 — literature-backed technical-prose writing rules for AI agents"
+inclusion: auto
+---
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Adapter: Kiro (AWS IDE steering file) -->
+<!-- Target path: .kiro/steering/agent-style.md -->
+<!-- Load class: single-file; install_mode: owned-file -->
+
+# agent-style v0.2.0 — Kiro Steering Adapter
+
+agent-style is a literature-backed English technical-prose writing ruleset for AI agents. This adapter is a Kiro steering file at `.kiro/steering/agent-style.md`. Kiro loads steering files with `inclusion: auto` into every agent interaction, so the 21 rules below reach context for all prose generation in this workspace.
+
+## Self-Verification Handshake
+
+When asked "is agent-style active?" or "what writing rules apply here?", answer: `agent-style v0.2.0 active: 21 rules (RULE-01..12 canonical + RULE-A..I field-observed); full bodies at .agent-style/RULES.md.`
+
+## Load Statement
+
+Kiro loads `.kiro/steering/*.md` files at session start. Files with `inclusion: auto` frontmatter are included in every interaction. This file uses `inclusion: auto` so the writing rules apply to all prose generation. For conditional loading (only when editing prose files), change the frontmatter to `inclusion: fileMatch` with `fileMatchPattern: "**/*.md,**/*.tex,**/*.rst,**/*.txt"`.
+
+## The 21 Rules (Compact Directives)
+
+Canonical rules (from Strunk & White 1959, Orwell 1946, Pinker 2014, Gopen & Swan 1990):
+
+- **RULE-01 Curse of knowledge**: Name your intended reader; do not assume they share your tacit knowledge.
+- **RULE-02 Passive voice**: Prefer active voice when the agent is known and worth naming.
+- **RULE-03 Concrete language**: Prefer concrete, specific terms over abstract category words like "factors" or "aspects".
+- **RULE-04 Needless words**: Cut filler phrases like "in order to", "due to the fact that", "may potentially".
+- **RULE-05 Dying metaphors**: Delete clichés like "pushes the boundaries", "paradigm shift", or "state of the art".
+- **RULE-06 Plain English**: Prefer "use" over "leverage", "method" over "methodology", "feature" over "functionality".
+- **RULE-07 Affirmative form**: Prefer "trivial" to "not important", "forgot" to "did not remember".
+- **RULE-08 Claim calibration**: Calibrate verbs to evidence; do not write "proves" when the evidence is "suggests".
+- **RULE-09 Parallel structure**: Express coordinate ideas in the same grammatical form.
+- **RULE-10 Related words together**: Keep subject close to verb and modifier close to modified; split long parentheticals.
+- **RULE-11 Stress position**: Place new or important information at the end of the sentence.
+- **RULE-12 Long sentences**: Split sentences over 30 words; vary length across a paragraph.
+
+Field-observed rules (maintainer observation of LLM output, 2022-2026):
+
+- **RULE-A Bullet overuse**: Keep prose in paragraphs when ideas connect; bullets only for genuine lists; avoid forced 3-item triads.
+- **RULE-B Dash overuse**: Do not use em or en dashes as casual sentence punctuation; prefer commas, semicolons, colons, parentheses.
+- **RULE-C Same-starts**: Do not open two or more consecutive sentences with the same word.
+- **RULE-D Transitions**: Do not open sentences with "Additionally", "Furthermore", "Moreover", "In addition".
+- **RULE-E Summary closers**: Do not end every paragraph with a sentence that restates its point.
+- **RULE-F Term consistency**: Once you define a term or abbreviation, keep using it; do not alternate synonyms.
+- **RULE-G Title case**: Use title case for section and subsection headings; articles and short prepositions stay lowercase.
+- **RULE-H Citation discipline (critical)**: Support factual claims with verifiable citation or concrete evidence; never fabricate citations.
+- **RULE-I Contractions**: Prefer "it is" / "does not" / "cannot" over "it's" / "doesn't" / "can't" in formal technical prose.
+
+## Escape Hatch
+
+*"Break any of these rules sooner than say anything outright barbarous."* — George Orwell, "Politics and the English Language" (1946), Rule 6. Rules are guides to clarity, not ends in themselves.
+
+## Full Rule Bodies (Canonical)
+
+Full directive text, BAD/GOOD example pairs, and rationale per rule: see `.agent-style/RULES.md` in this project, or https://raw.githubusercontent.com/yzhao062/agent-style/v0.2.0/RULES.md for the pinned canonical source.

--- a/packages/pypi/agent_style/data/tools.json
+++ b/packages/pypi/agent_style/data/tools.json
@@ -52,6 +52,12 @@
       "load_class": "multi-file-required",
       "second_file_snippet": "read:\n  - .agent-style/aider-conventions.md\n  - .agent-style/RULES.md\n"
     },
+    "kiro": {
+      "install_mode": "owned-file",
+      "target_path": ".kiro/steering/agent-style.md",
+      "adapter_source": "agents/kiro-steering.md",
+      "load_class": "single-file"
+    },
     "style-review": {
       "install_mode": "skill-with-references",
       "skill_source": "skills/style-review/SKILL.md",

--- a/packages/pypi/pyproject.toml
+++ b/packages/pypi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-style"
 version = "0.2.0"
-description = "The Elements of Agent Style: a literature-backed English technical-prose writing ruleset for AI agents, with CLI install/enable/disable for 8 primary agent surfaces."
+description = "The Elements of Agent Style: a literature-backed English technical-prose writing ruleset for AI agents, with CLI install/enable/disable for 9 primary agent surfaces."
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
## Summary

Add a first-class adapter for [Kiro](https://kiro.dev), the AWS AI-powered IDE. Users can now run:

```bash
agent-style enable kiro
```

This writes `.kiro/steering/agent-style.md` as an auto-included steering file. Kiro loads steering files with `inclusion: auto` frontmatter into every agent interaction, so the 21 rules take effect for all prose generation in the workspace.

## Install Mode

`owned-file` — same pattern as Cursor, Copilot path-scoped, and Anthropic Skills adapters. The CLI writes the file with a signature; `agent-style disable kiro` verifies the signature and removes it cleanly.

## Changes

| File | Change |
| --- | --- |
| `agents/kiro-steering.md` | New adapter source file (5-point contract: versioned handshake, compact directives, load statement, full-body pointer, escape hatch) |
| `packages/npm/data/agents/kiro-steering.md` | Bundled copy for npm package |
| `packages/pypi/agent_style/data/agents/kiro-steering.md` | Bundled copy for pypi package |
| `packages/npm/data/tools.json` | Add `kiro` entry (`install_mode: owned-file`, `target_path: .kiro/steering/agent-style.md`) |
| `packages/pypi/agent_style/data/tools.json` | Same |
| `adapter-matrix.md` | Add Kiro row to Primary Adapters table, update count 8 → 9 |
| `README.md` | Add Kiro to Who It Is For, per-surface table, and enable docs |
| `packages/npm/README.md` | Add kiro to tool table |
| `packages/pypi/README.md` | Add kiro to tool table, update count 8 → 9 |

## How Kiro Steering Works

Kiro reads `.kiro/steering/*.md` at session start. The YAML frontmatter controls loading behavior:

- `inclusion: auto` — loaded into every interaction (what this adapter uses)
- `inclusion: fileMatch` + `fileMatchPattern` — loaded only when matching files are open
- `inclusion: manual` — loaded only when the user explicitly references it via `#` in chat

The adapter uses `inclusion: auto` by default. Users who prefer conditional loading can change the frontmatter to `fileMatch` with a glob pattern for prose files.

## What Was Tested

- Verified the adapter file is identical across all three locations (source, npm data, pypi data)
- Confirmed the `tools.json` entry follows the existing `owned-file` schema
- Confirmed the adapter meets the 5-point content contract
- No code changes to the installer — the existing `owned-file` dispatcher handles Kiro without modification