### PR TITLE
docs: add USAGE.md with CI integration, custom rules, and violation output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,247 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# Contributing to agent-style
+
+Thank you for contributing. This guide covers the two most common contribution types: **adding or modifying rules** and **opening pull requests**.
+
+---
+
+## How to Add a Rule
+
+### 1. Propose the rule with evidence
+
+Before writing code, open a GitHub Discussion describing:
+
+- The failure mode in AI-generated prose (with before/after examples)
+- Whether it is a chronic AI-tell (field-observed) or a violation of a classical writing principle (canonical)
+- The proposed directive (one sentence, negative for anti-patterns, positive for constructive rules)
+- The proposed scope (file types and document kinds where the rule applies)
+
+Rule proposals with at least 5 real before/after examples (from bench drafts or production output) are prioritized.
+
+### 2. Name the rule
+
+Follow the naming conventions below. Get the next ID from the current RULES.md:
+
+- **Canonical rules** — `RULE-01` through `RULE-12` + full name. These cite classical writing authorities (Strunk & White, Orwell, Pinker, Gopen & Swan). Do not reuse a canonical ID.
+- **Field-observed rules** — `RULE-A` through `RULE-I` + full name. These capture LLM-specific failure modes observed in AI output. The letter sequence is reserved for field-observed rules that are confirmed in production bench data. Do not use letters outside this range.
+
+**Rule full names** use Title Case and follow the pattern: *"Do Not [anti-pattern]"* or *"Do [positive behavior]."* Keep names under 70 characters.
+
+### 3. Add the rule to RULES.md
+
+Each rule entry in RULES.md must include:
+
+```markdown
+#### RULE-XX: Full Name
+
+- **source**: Author Year, Chapter or Section or Essay Rule
+- **agent-instruction evidence**: Citation that supports negative phrasing + example pairing (Zhang et al. 2026, Bohr 2025)
+- **severity**: critical | high | medium | low
+- **scope**: file extensions and document kinds
+- **enforcement**: Tier-1 through Tier-4 (see Enforcement below)
+
+##### Directive
+
+One command-form sentence. Negative for anti-patterns ("Do not..."), positive for constructive rules.
+
+##### BAD → GOOD
+
+At least 5 examples covering at least 3 document types (e.g., API docs, runbooks, research papers, release notes, postmortems, proposals, issue reports). Each BAD → GOOD pair must show the same content rewritten per the rule.
+
+##### Rationale for AI Agent
+
+One paragraph explaining why the rule specifically matters for LLM-generated prose, not just human writing.
+```
+
+**Severity rubric:**
+
+| Level | Meaning |
+| --- | --- |
+| critical | Reader cannot understand or trust the prose if violated |
+| high | Recurring AI-tell or clarity failure that breaks skim-reading |
+| medium | Local readability cost, felt but not trust-breaking |
+| low | Polish; flagged for consistency rather than comprehension |
+
+**Enforcement tiers:**
+
+| Tier | Mechanism | When used |
+| --- | --- | --- |
+| 1 | Tier-1 deny (regex or simple pattern match) | High-precision anti-patterns only |
+| 2 | Tier-2 external linter (LanguageTool PASSIVE_VOICE, etc.) | Rules with validated external tooling |
+| 3 | Tier-3 agent self-check (judgment rule) | Rules requiring contextual judgment |
+| 4 | Tier-4 Codex review as primary gate | Rules needing LLM-level evaluation |
+
+### 4. Add test fixtures
+
+Fixture-driven tests live in `packages/pypi/agent_style/data/skills/style-review/references/fixture-prose/`.
+
+Create a `<name>.md` fixture and a `<name>.expected.json` sibling:
+
+```json
+{
+  "total_violations": 3,
+  "per_rule_count": {
+    "RULE-01": 1,
+    "RULE-06": 2
+  },
+  "expected_skipped_rules": ["RULE-H"]
+}
+```
+
+Run the fixture tests before committing:
+
+```bash
+cd packages/pypi
+python -m pytest tests/test_review_fixtures.py -v
+```
+
+### 5. Regenerate rule-pack artifacts
+
+After modifying RULES.md, regenerate the derived artifacts:
+
+```bash
+python scripts/build-compact.py
+```
+
+Then commit the changed files:
+
+```
+docs/rule-pack.md
+docs/rule-pack-compact.md
+packages/pypi/agent_style/data/RULES.md
+packages/pypi/agent_style/data/rule-pack-compact.md
+packages/npm/data/RULES.md
+packages/npm/data/rule-pack-compact.md
+```
+
+The `validate.yml` CI workflow will fail if these are out of date.
+
+---
+
+## Rule Naming Conventions
+
+### ID format
+
+| Group | Pattern | Example |
+| --- | --- | --- |
+| Canonical | `RULE-NN` (two digits) | `RULE-01`, `RULE-12` |
+| Field-observed | `RULE-X` (single letter) | `RULE-A`, `RULE-H` |
+
+### Full name format
+
+- Title Case, imperative mood
+- Anti-pattern rules: *"Do Not [behavior]"*
+- Positive rules: *"Do [behavior]"*
+- Maximum 70 characters
+- No articles ("a", "an", "the") unless part of a fixed phrase
+
+### Examples
+
+```
+RULE-01: Do Not Assume the Reader Shares Your Tacit Knowledge
+RULE-06: Do Not Use Avoidable Jargon Where an Everyday English Word Exists
+RULE-H:  Cite Sources for Quantitative Claims and Specific Assertions
+```
+
+### What goes in which group
+
+**Canonical (RULE-01..12):** Violations of classical writing authority. Each must cite a source by chapter, section, or essay rule. Citations must be verified against the original work.
+
+**Field-observed (RULE-A..I):** Patterns observed in AI output across writing projects. These do not require a classical source citation but require evidence from real AI-generated prose (bench drafts, production output).
+
+---
+
+## Testing Requirements
+
+### Fixture-driven tests (required for every rule change)
+
+Location: `packages/pypi/tests/test_review_fixtures.py`
+
+These tests load every `.md` fixture in `fixture-prose/`, run the audit, and assert per-rule violation counts match the sibling `.expected.json`. If a rule's behavior changes intentionally, the corresponding `.expected.json` must be updated in the same commit.
+
+Run locally:
+
+```bash
+cd packages/pypi
+python -m pytest tests/test_review_fixtures.py -v
+```
+
+### Skill safety smoke tests
+
+The skill safety suite (`scripts/smoke-skill-safety.sh`) validates:
+
+- Ownership proof and atomicity on partial failure
+- Drift fail-closed behavior
+- Path-traversal rejection
+
+Run locally:
+
+```bash
+bash scripts/smoke-skill-safety.sh        # both Python and Node CLIs
+bash scripts/smoke-skill-safety.sh py     # Python only
+bash scripts/smoke-skill-safety.sh node   # Node only
+```
+
+### Markdown linting and link checks
+
+CI runs these on every push. Run locally before opening a PR:
+
+```bash
+# markdownlint-cli2 (Node, requires npm)
+npx markdownlint-cli2 "**/*.md"
+
+# markdown link check (Node)
+npx markdown-link-check --config .github/mlc-config.json README.md
+```
+
+### Rule-pack parity check
+
+The `validate.yml` workflow verifies that `RULES.md` and the generated rule-pack artifacts are in sync. Run locally:
+
+```bash
+python scripts/build-compact.py
+git diff --exit-code -- \
+  docs/rule-pack.md \
+  docs/rule-pack-compact.md \
+  packages/pypi/agent_style/data/RULES.md \
+  packages/pypi/agent_style/data/rule-pack-compact.md \
+  packages/npm/data/RULES.md \
+  packages/npm/data/rule-pack-compact.md
+```
+
+---
+
+## Pull Request Checklist
+
+Before opening a PR, confirm:
+
+- [ ] **Rule change:** RULES.md entry is complete (source, severity, scope, enforcement tier, directive, 5+ BAD→GOOD examples, rationale for AI agent)
+- [ ] **Fixture:** New or updated fixture with matching `.expected.json`; `test_review_fixtures.py` passes
+- [ ] **Artifacts:** `scripts/build-compact.py` run; all changed generated files committed
+- [ ] **Skill safety:** `scripts/smoke-skill-safety.sh` passes (both py and node)
+- [ ] **Lint:** `markdownlint-cli2 "**/*.md"` passes with no new errors
+- [ ] **Links:** Markdown link check passes on modified files
+- [ ] **CHANGELOG.md:** Entry added under `## Unreleased` with rule name, brief description, and PR number
+- [ ] **Scope:** Changes are within scope (technical prose: API docs, design docs, research papers, proposals, READMEs, runbooks, commit messages, error messages, release notes, postmortems, issue reports)
+
+### Out of scope
+
+Do not submit rules for:
+
+- Fiction, poetry, marketing copy
+- Long-form narrative non-fiction
+- Non-English prose
+- Any context where rhythm or affect matters more than precision
+
+---
+
+## CI Validation
+
+All PRs run the `validate.yml` workflow, which includes:
+
+1. **Markdown lint** — `markdownlint-cli2` across all `.md` files
+2. **Link check** — `markdown-link-check` for all hyperlinks
+3. **Rule-pack parity** — `build-compact.py` regeneration check
+
+A green CI run is required before merging. If linting errors appear, fix them before requesting review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ python scripts/build-compact.py
 
 Then commit the changed files:
 
-```
+```text
 docs/rule-pack.md
 docs/rule-pack-compact.md
 packages/pypi/agent_style/data/RULES.md
@@ -138,7 +138,7 @@ The `validate.yml` CI workflow will fail if these are out of date.
 
 ### Examples
 
-```
+```text
 RULE-01: Do Not Assume the Reader Shares Your Tacit Knowledge
 RULE-06: Do Not Use Avoidable Jargon Where an Everyday English Word Exists
 RULE-H:  Cite Sources for Quantitative Claims and Specific Assertions

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,302 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# Agent-Style Usage Guide
+
+This guide covers three topics not fully addressed in the README: running `agent-style` in CI, adding custom rules, and interpreting the violation output from `agent-style review`.
+
+---
+
+## Table of Contents
+
+- [CI Integration](#ci-integration)
+- [Adding Custom Rules](#adding-custom-rules)
+- [Interpreting Violation Output](#interpreting-violation-output)
+
+---
+
+## CI Integration
+
+`agent-style` runs in CI via two paths: the **review audit** (post-hoc, catches violations after generation) and **ProseLint** (post-hoc linter, catches a subset of mechanical violations on committed prose).
+
+Both run as standard shell commands; any CI platform works.
+
+### 1. Review Audit in CI
+
+The `agent-style review --audit-only` command emits machine-readable JSON and exits non-zero when violations are found. Use this to gate PRs or fail builds.
+
+```yaml
+# .github/workflows/style-check.yml
+name: agent-style review
+
+on:
+  pull_request:
+    paths:
+      - "**.md"          # only prose files
+      - ".agent-style/"  # or if agent-style config changes
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install agent-style
+        run: pip install agent-style
+
+      - name: Run agent-style review
+        id: review
+        run: |
+          # Review all markdown files, fail on any violation
+          # --audit-only: JSON output, no polish
+          # Exit code 3 means violations found; treat as failure
+          agent-style review . --audit-only --output-format=json || {
+            exit_code=$?
+            if [ $exit_code -eq 3 ]; then
+              echo "agent-style violations found — see output above"
+              exit 1
+            fi
+            # Re-throw unexpected errors
+            exit $exit_code
+          }
+```
+
+**Tip:** Add `--output-format=json` and parse the `summary.total` field if you want to threshold violations (e.g., fail only when `critical` > 0).
+
+### 2. ProseLint in CI (Mechanical Subset)
+
+For a faster, language-tool-based linter that catches filler phrases, clichés, jargon, and passive voice, run ProseLint in CI using the mapping in [`enforcement/proselint-map.md`](../enforcement/proselint-map.md).
+
+```yaml
+# .github/workflows/proselint.yml
+name: ProseLint
+
+on: [push, pull_request]
+
+jobs:
+  proselint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ProseLint
+        run: pip install proselint
+
+      - name: Run ProseLint on markdown files
+        run: |
+          # Run on all markdown, stop on first error
+          find . -name "*.md" -not -path "./.agent-style/*" | xargs proselint
+```
+
+**What ProseLint catches vs. what it misses:**
+
+| Caught by ProseLint | Not caught (needs `style-review` skill) |
+| --- | --- |
+| RULE-04 filler phrases | RULE-01 curse-of-knowledge (semantic) |
+| RULE-05 clichés/dying metaphors | RULE-03 vague/abstract language (semantic) |
+| RULE-06 jargon | RULE-08 uncalibrated claims (semantic) |
+| RULE-02 passive voice (via `misc.passive_voice`) | RULE-H unsupported claims (semantic) |
+| RULE-12 long sentences | RULE-01 / RULE-03 context-dependent violations |
+
+ProseLint is a fast subset gate; `agent-style review` with a skill host catches the full 21-rule set.
+
+### 3. Pre-Commit Hook (Local CI)
+
+For local pre-commit enforcement (before files are ever committed):
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: agent-style-review
+        name: agent-style review
+        entry: agent-style review --audit-only
+        language: system
+        files: \.md$
+        pass_filenames: true
+```
+
+Install with: `pip install pre-commit && pre-commit install`
+
+---
+
+## Adding Custom Rules
+
+Agent-style has two rule tracks: **canonical** (sourced from writing authorities) and **field-observed** (RULE-A through RULE-I, logged from LLM output). You can add your own field-observed rules following the same format.
+
+### Adding a Field-Observed Rule (RULE-X)
+
+**Step 1: Define the rule in `RULES.md`**
+
+Add a new section following the existing RULE-A through RULE-I format. The required fields are:
+
+```markdown
+#### RULE-X: <Short Title>
+
+- **source**: field-observed (your name or team, year range)
+- **agent-instruction evidence**: <cite any relevant papers or internal studies>
+- **severity**: critical | high | medium | low
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 deny | Tier-2 | Tier-3 agent self-check | Tier-4 Codex review
+
+##### Directive
+
+<One to three sentences in command form — negative for anti-patterns,
+positive for constructive rules. Use "Do not..." for violations,
+"Do ..." for constructive rules.>
+
+##### BAD → GOOD
+
+<At least 5 BAD → GOOD examples. Include at least one non-paper context
+(API docs, runbooks, proposals, release notes, postmortems, changelogs,
+or issue reports). Each example should be a real pattern you have seen
+in your LLM output.>
+
+##### Rationale for AI Agent
+
+<2-4 sentences explaining why this rule specifically matters for
+LLM-generated prose. What training-signal or failure-mode does it address?>
+```
+
+**Step 2: Add the mechanical detector (if applicable)**
+
+If the rule has a mechanical, regex-detectable pattern, add it to the appropriate detector in `packages/pypi/agent_style/review/primitive.py` or as a deny-phrase entry in `enforcement/deny-phrases.txt`.
+
+For rules that need semantic judgment (like RULE-01, RULE-03), add the rule ID to the `semantic` list in the skill's `SKILL.md` workflow, so the style-review skill routes it to the host model.
+
+**Step 3: Update the rule count in adapters**
+
+Regenerate the compact adapter files to include the new rule:
+
+```bash
+python scripts/build-compact.py
+```
+
+**Step 4: Test the new rule**
+
+```bash
+# Mechanical-only test
+agent-style review path/to/test-file.md --audit-only
+
+# Full skill test (if semantic)
+# Run inside Claude Code with style-review enabled:
+/style-review path/to/test-file.md
+```
+
+### Disabling a Rule in a Project
+
+To disable a specific rule locally without removing it from the shared ruleset:
+
+There is no per-rule disable flag yet (planned for v1.1 per the roadmap). As a workaround:
+
+1. **Soft enforcement:** Edit `.agent-style/RULES.md` and comment out or remove the rule's section before enabling.
+2. **Skill:** You cannot currently override a rule for the skill; the skill always audits all 21 rules.
+
+---
+
+## Interpreting Violation Output
+
+### JSON Output Format (`--audit-only`)
+
+```bash
+agent-style review path/to/file.md --audit-only
+```
+
+```json
+{
+  "file": "path/to/file.md",
+  "summary": {
+    "total": 6,
+    "critical": 1,
+    "high": 2,
+    "medium": 3,
+    "low": 0,
+    "rules_triggered": ["RULE-01", "RULE-B", "RULE-H", "RULE-12"]
+  },
+  "violations": [
+    {
+      "rule": "RULE-H",
+      "severity": "critical",
+      "line": 14,
+      "excerpt": "This approach is widely adopted in the industry.",
+      "message": "Support factual claims with citation or concrete evidence; do not be handwavy.",
+      "fix_required": "Add a citation or concrete evidence for the claim."
+    },
+    {
+      "rule": "RULE-B",
+      "severity": "high",
+      "line": 22,
+      "excerpt": "The service — which had been running for 3 weeks — crashed.",
+      "message": "Do not use em or en dashes as casual sentence punctuation.",
+      "fix_required": "Replace the em-dash sentence break with a period or semicolon."
+    }
+  ]
+}
+```
+
+### Severity Levels
+
+| Severity | Meaning | What to do |
+| --- | --- | --- |
+| **critical** | Reader cannot trust or understand the prose | Fix before merge |
+| **high** | Visible AI-tell or recurring clarity failure | Fix before merge |
+| **medium** | Local readability cost | Address in next polish pass |
+| **low** | Polish / consistency | Nice to fix, not blocking |
+
+**RULE-H (citation discipline)** and **RULE-01 (curse of knowledge)** are the two most likely to be critical in research and technical documentation contexts.
+
+### Deterministic vs. Semantic Rules
+
+When you run `agent-style review` from the CLI (no skill host), some rules return `status: "skipped"` because they need semantic judgment:
+
+```json
+{
+  "rule": "RULE-01",
+  "status": "skipped",
+  "detector": "semantic",
+  "reason": "Requires host model for context-aware judgment"
+}
+```
+
+The style-review skill (`/style-review FILE` inside Claude Code) fills in these semantic rules by routing them to the host model. If you need the full 21-rule audit without a skill host, the mechanical subset (RULE-B, D, G, I, 12, 05, 06, A, C, E) is fully covered.
+
+### Exit Codes
+
+| Exit code | Meaning |
+| --- | --- |
+| 0 | No violations found |
+| 1 | Internal error (file not found, parse error, etc.) |
+| 2 | Usage error (bad flag, missing argument) |
+| 3 | Violations found — see JSON output |
+
+### Reading the Per-Rule Count
+
+The scorecard emitted by `agent-style review FILE` shows counts per rule:
+
+```
+RULE-01 (curse of knowledge)     ██████████░░░░░░  10
+RULE-B (em-dash punctuation)     ████░░░░░░░░░░░░   4
+RULE-H (citation discipline)      ██░░░░░░░░░░░░░░   2
+RULE-12 (long sentences)          ██░░░░░░░░░░░░░░   2
+```
+
+A high count on RULE-B or RULE-D almost always reflects a model that overuses dashes or transition openers by default. RULE-01 is typically the largest count in longer documents because every unexplained acronym or assumed prerequisite adds a tick.
+
+### Comparing Two Drafts
+
+```bash
+agent-style review --compare baseline.md revised.md
+```
+
+This emits a per-rule delta table showing which rules improved, which got worse, and which are new:
+
+```
+Rule             | Baseline | Revised | Δ
+-----------------|----------|---------|---
+RULE-01          |    8     |    3    | -5
+RULE-B           |    4     |    0    | -4
+RULE-H           |    2     |    2    |  0
+RULE-12          |    3     |    5    | +2   ← sentence splitting over-corrected
+```
+
+A `+N` delta on RULE-12 means the revision split sentences but may have over-split. Review those cases manually.


### PR DESCRIPTION
Adds docs/USAGE.md with:

- **CI Integration** — GitHub Actions workflow examples for agent-style review (JSON/exit-code gating) and ProseLint (mechanical subset), plus pre-commit hook config.
- **Adding Custom Rules** — Step-by-step guide to adding a field-observed RULE-X rule to RULES.md.
- **Interpreting Violation Output** — JSON schema, severity rubric, deterministic vs semantic rule split, exit codes, and compare-delta format.

Target: okwn/agent-style:main